### PR TITLE
update example deployment manifest to compatible with k8s 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,15 @@ $ kubectl create -f https://raw.githubusercontent.com/awslabs/aws-virtual-gpu-de
 Virtual NVIDIA GPUs can now be consumed via container level resource requirements using the resource name `k8s.amazonaws.com/vgpu`:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: resnet-deployment
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: resnet-server
   template:
     metadata:
       labels:

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ Enter python client pod we created.
 ```shell
 $ kubectl exec -it python-client bash
 
-$ apt update && apt install -y vim
+$ apt update && apt install -y vim && pip install requests
 ```
 
 Prepare model client, copy the scripts from [resnet_client.py](./resnet_client.py)

--- a/examples/resnet.yaml
+++ b/examples/resnet.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: resnet-deployment
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: resnet-server
   template:
     metadata:
       labels:


### PR DESCRIPTION
Fix #4 

*Description of changes:*
update api version and seletor in example deployment manifest to make it compatible with k8s 1.16+


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
