### PR TITLE
Updated device-plugin.yaml with nvidia-cuda tag

### DIFF
--- a/manifests/device-plugin.yml
+++ b/manifests/device-plugin.yml
@@ -37,7 +37,7 @@ spec:
       # In case machine deploy MPS device plugin and change compute mode to
       initContainers:
       - name: set-compute-mode
-        image: nvidia/cuda:latest
+        image: nvidia/cuda:11.3.0-runtime-ubuntu18.04
         command: ['nvidia-smi', '-c', 'EXCLUSIVE_PROCESS']
         securityContext:
           capabilities:


### PR DESCRIPTION
*Issue #, if available:*

Manifest fails since latest tag is deprecated, moving to nvidia/cuda:11.3.0-runtime-ubuntu18.04

*Description of changes:*

Move from nvidia/cuda:latest -> nvidia/cuda:11.3.0-runtime-ubuntu18.04

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
