### PR TITLE
Update device-plugin.yml

### DIFF
--- a/manifests/device-plugin.yml
+++ b/manifests/device-plugin.yml
@@ -11,10 +11,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      # This annotation is deprecated. Kept here for backward compatibility
-      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         name: aws-virtual-gpu-device-plugin
     spec:


### PR DESCRIPTION
remove warnings in k8s 1.16+

*Issue #, if available:*

*Description of changes:*
When applying it to AWS EKS 1.16+ its hit. warning, the lines are removed so it's not sending info back again, 1.16 a very old version of Kubernetes, and the fixes are already added to the manifest but the lines are forgotten to be removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
